### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/lightrag/kg/tidb_impl.py
+++ b/lightrag/kg/tidb_impl.py
@@ -102,7 +102,7 @@ class TiDB:
                 sanitized_params = sanitize_sensitive_info(params)
                 sanitized_error = sanitize_sensitive_info({"error": str(e)})
                 logger.error(
-                    f"Tidb database,\nsql:{sql},\nparams:{sanitized_params},\nerror:{sanitized_error}"
+                    f"Tidb database error occurred while executing SQL query. Please check the logs for more details."
                 )
                 raise
             if multirows:


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/LightRAG/security/code-scanning/3](https://github.com/venkateshpabbati/LightRAG/security/code-scanning/3)

To fix the problem, we should avoid logging sensitive data entirely. Instead of sanitizing sensitive fields and logging them, we can log a generic message that does not include sensitive information. This ensures that no sensitive data is exposed, even inadvertently.

The changes involve:
1. Modifying the logging statement on line 105 to exclude sensitive data (`params` and `error`).
2. Logging a generic message that indicates an error occurred without exposing sensitive details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
