### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -191,7 +191,8 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
                                 yield f"{json.dumps({'response': chunk})}\n"
                     except Exception as e:
                         logging.error(f"Streaming error: {str(e)}")
-                        yield f"{json.dumps({'error': str(e)})}\n"
+                        trace_exception(e)
+                        yield f"{json.dumps({'error': 'An internal error occurred'})}\n"
 
             return StreamingResponse(
                 stream_generator(),
@@ -205,6 +206,6 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             )
         except Exception as e:
             trace_exception(e)
-            raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(status_code=500, detail="An internal error occurred")
 
     return router


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/LightRAG/security/code-scanning/6](https://github.com/venkateshpabbati/LightRAG/security/code-scanning/6)

To fix the issue, we need to ensure that sensitive information from exceptions is not exposed to external users. Instead, we should log the detailed stack trace internally for debugging purposes and return a generic error message to the user. This approach balances security and maintainability.

Specifically:
1. Replace the `str(e)` in the response JSON with a generic error message, such as `"An internal error occurred"`.
2. Ensure the detailed exception information is logged using the `trace_exception(e)` function for developer access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
